### PR TITLE
Fix when hash is inner a value of a variable that escaped by quote

### DIFF
--- a/js/DotEnvParser.js
+++ b/js/DotEnvParser.js
@@ -12,10 +12,18 @@ class DotEnvParser {
     }
   }
 
+  static removeComments(str) {
+    if (str.includes('="') && str.endsWith('"')) {
+      return str;
+    } else  {
+      return str.replace(/#.*/, '');
+    }
+  }
+
   static parseEnvStr(str) {
     str = str.trim();
     str = str.replace(/^export /, '');
-    str = str.replace(/#.*/, '');
+    str = DotEnvParser.removeComments(str);
     let parts = str.split('=');
     let name = parts[0].trim();
     let valid = new RegExp(`^${config.regex}$`).test(name);

--- a/test/_classes/optionsTestObjs.js
+++ b/test/_classes/optionsTestObjs.js
@@ -136,6 +136,21 @@ let envsub = [
     }
   },
   {
+    testName: '--env-file should remove quotes surrounding environment variables and let all character on it ',
+    preFunc: () => {
+    },
+    templateFile: Tmp.ENV_TEMPLATE_NOT_A_COMMENT_FILE,
+    outputContents: Tmp.ENV_TEMPLATE_NOT_A_COMMENT_FILE_EXPECTED,
+    options: {
+      envFiles: [
+        Tmp.ENVFILE9
+      ]
+    },
+    cli: {
+      flags: `--env-file ${Tmp.ENVFILE9}`.split(' ')
+    }
+  },
+  {
     testName: '--env-file should not substitute environment variables with invalid names',
     templateFile: Tmp.ENV_INVALID_TEMPLATE_FILE,
     outputContents: Tmp.ENV_INVALID_TEMPLATE_FILE_EXPECTED,

--- a/test/_classes/templateFiles.js
+++ b/test/_classes/templateFiles.js
@@ -10,12 +10,16 @@ const ENVFILE5 = `${envsubDir}/envFile5.env`;
 const ENVFILE6 = `${envsubDir}/envFile6.env`;
 const ENVFILE7 = `${envsubDir}/envFile7.env`;
 const ENVFILE8 = `${envsubDir}/envFile8.env`;
+const ENVFILE9 = `${envsubDir}/envFile9.env`;
 
 const COMBINED_TEMPLATE_FILE = `${envsubDir}/templateFileCombined`;
 const COMBINED_TEMPLATE_FILE_EXPECTED = readFileSync(`${envsubDir}/templateFileCombined_E`, 'utf8');
 
 const ENV_TEMPLATE_FILE = `${envsubDir}/templateFileEnv`;
+
 const ENV_TEMPLATE_FILE_EXPECTED = readFileSync(`${envsubDir}/templateFileEnv_E`, 'utf8');
+const ENV_TEMPLATE_NOT_A_COMMENT_FILE = `${envsubDir}/templateFileNotAComment`;
+const ENV_TEMPLATE_NOT_A_COMMENT_FILE_EXPECTED = readFileSync(`${envsubDir}/templateFileNotAComment_E`, 'utf8');
 const ENV_FILE_TEMPLATE_FILE = `${envsubDir}/templateFileEnvFile`;
 const ENV_FILE_TEMPLATE_FILE_EXPECTED = readFileSync(`${envsubDir}/templateFileEnvFile_E`, 'utf8');
 const ENV_INVALID_TEMPLATE_FILE = `${envsubDir}/templateFileEnvInvalid`;
@@ -74,6 +78,9 @@ const templateFiles = {
     ENVFILE6,
     ENVFILE7,
     ENVFILE8,
+    ENVFILE9,
+    ENV_TEMPLATE_NOT_A_COMMENT_FILE,
+    ENV_TEMPLATE_NOT_A_COMMENT_FILE_EXPECTED,
     COMBINED_TEMPLATE_FILE,
     COMBINED_TEMPLATE_FILE_EXPECTED,
     ENV_TEMPLATE_FILE,

--- a/test/envsub-global/envFile9.env
+++ b/test/envsub-global/envFile9.env
@@ -1,0 +1,1 @@
+NOT_A_COMMENT="Daniel#not_a_comment"

--- a/test/envsub-global/templateFileNotAComment
+++ b/test/envsub-global/templateFileNotAComment
@@ -1,0 +1,2 @@
+xxx${ NOT_A_COMMENT }xxx xxx${ NOT_A_COMMENT }xxx
+xxx${NOT_A_COMMENT}xxx xxx${   NOT_A_COMMENT   }xxx

--- a/test/envsub-global/templateFileNotAComment_E
+++ b/test/envsub-global/templateFileNotAComment_E
@@ -1,0 +1,2 @@
+xxxDaniel#not_a_commentxxx xxxDaniel#not_a_commentxxx
+xxxDaniel#not_a_commentxxx xxxDaniel#not_a_commentxxx


### PR DESCRIPTION
I found an issue in case of `MYVAR="anyvalue#anyvalue"` will be compute to "anyvalue instead of anyvalue#anyvalue.  so we can't escape hash character